### PR TITLE
enable installing via script

### DIFF
--- a/scripts/InstallAzureAICLIDeb-v11.sh
+++ b/scripts/InstallAzureAICLIDeb-v11.sh
@@ -56,10 +56,11 @@ if ! command -v dotnet &> /dev/null; then
             sudo dpkg -i packages-microsoft-prod.deb
             rm packages-microsoft-prod.deb
         elif [[ "$CHECK_VERSION" == "22.04" ]]; then
-            # Install the Microsoft package signing key for Ubuntu 22.04
-            wget https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
-            sudo dpkg -i packages-microsoft-prod.deb
-            rm packages-microsoft-prod.deb
+            # We don't need to install the Microsoft package signing key for Ubuntu 22.04; in fact, if we do, `dotnet tool` doesn't work
+            echo "Ubuntu 22.04 detected. Skipping Microsoft package signing key installation."
+            # wget https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+            # sudo dpkg -i packages-microsoft-prod.deb
+            # rm packages-microsoft-prod.deb
         else
             echo "Unsupported Ubuntu version: $CHECK_VERSION"
             exit 1


### PR DESCRIPTION
You can now install via script. As an example, I uploaded this script so the following command will install alpha11:
```bash
curl -SL https://crbn.us/InstallAzureAICLIDeb | bash
```