### PR TITLE
fix(installer): Write $PATH to $ZDOTDIR/.zshrc

### DIFF
--- a/scripts/InstallAzureAICLIDeb.sh
+++ b/scripts/InstallAzureAICLIDeb.sh
@@ -136,8 +136,8 @@ fi
 # Add the .NET tools directory to the PATH
 echo ""
 echo "Adding $DOTNET_TOOLS_PATH to PATH..."
-export PATH="$DOTNET_TOOLS_PATH:$PATH"                               # For current shell
-echo "export PATH=\"$DOTNET_TOOLS_PATH:\$PATH\"" >> "$HOME/.bashrc"  # For bash
+export PATH="$DOTNET_TOOLS_PATH:$PATH"                                           # For current shell
+echo "export PATH=\"$DOTNET_TOOLS_PATH:\$PATH\"" >> "$HOME/.bashrc"              # For bash
 echo "export PATH=\"$DOTNET_TOOLS_PATH:\$PATH\"" >> "${ZDOTDIR:-$HOME}/.zshrc"   # For zsh (if using)
 echo ""
 echo "Don't forget to source your shell's rc file, for example:"


### PR DESCRIPTION
# Description

This pull request fixes a bug in the installer where it will write to the wrong `.zshrc` file if `$ZDOTDIR` is set.

# Background

`zsh` expects that startup files (`.zshenv`, `.zprofile`, `.zshrc`, `.zlogin`, `.zlogout`) exist in the directory specified by `$ZDOTDIR`. If $ZDOTDIR is unset, zsh will instead check $HOME.

See https://zsh.sourceforge.io/Intro/intro_3.html

The linux installer unconditionally writes to `$HOME/.zshrc`:

https://github.com/Azure/azure-ai-cli/blob/3ddce74e0417d69cd5ce745fe42fcb0cd0daf871/scripts/InstallAzureAICLIDeb.sh#L141

This has no effect for users with `$ZDOTDIR` set.