### PR TITLE
Fix Windows installer upgrades

### DIFF
--- a/scripts/Azure-AI-CLI.wxs
+++ b/scripts/Azure-AI-CLI.wxs
@@ -4,6 +4,12 @@
 <Product Id="*" Name="Azure AI CLI" Language="1033" Version="$(var.productVersion)" Manufacturer="Microsoft Corporation" UpgradeCode="F1CDBA9C-E353-4039-9A20-059A1E587E73">
     <Package InstallerVersion="500" Compressed="yes" InstallScope="perMachine" Platform="$(var.targetPlatform)"/>
     <!--
+    To prevent issues with bundle upgrades, use MajorUpgrade here and ProductSearch in the bundle wxs. This is a workaround for
+    https://stackoverflow.com/questions/15156081/wix-bundle-upgrade-a-new-version-of-msi-is-installed-before-the-old-version-is
+    -->
+    <MajorUpgrade AllowDowngrades="no" DowngradeErrorMessage="A newer version is already installed."/>
+
+    <!--
     Below can be used to control upgrades on a single MSI-only (non-bundle) installation.
     -->
     <!--


### PR DESCRIPTION
Re-add a condition to prevent removal of the CLI tool at the end of a bundle upgrade, and include a reference to the original issue as a reminder.