### PR TITLE
Update Windows installer

### DIFF
--- a/scripts/Azure-AI-CLI-Setup.wxs
+++ b/scripts/Azure-AI-CLI-Setup.wxs
@@ -42,14 +42,22 @@
 
     <Fragment>
         <!-- .NET SDK -->
-        <util:DirectorySearch Id="DotNetDirectory"
-                              Path="[ProgramFiles64Folder]dotnet\sdk\$(var.dotNetVersion)"
-                              Result="exists"
-                              Variable="DOTNET_SDK_INSTALLED"/>
+        <!--
+        There can be multiple SDK versions installed side by side on the system
+        and .NET provides no way of checking the highest or major version other
+        than by running the dotnet command and parsing the output, which is not
+        supported here. Thus need to check for each possible 8.x SDK folder and
+        if none is found then install the configured (highest) 8.x version.
+        -->
+        <util:DirectorySearch Id="DotNet80201" Path="[ProgramFiles64Folder]dotnet\sdk\8.0.201" Result="exists" Variable="NET_80201"/>
+        <util:DirectorySearch Id="DotNet80200" Path="[ProgramFiles64Folder]dotnet\sdk\8.0.200" Result="exists" Variable="NET_80200"/>
+        <util:DirectorySearch Id="DotNet80102" Path="[ProgramFiles64Folder]dotnet\sdk\8.0.102" Result="exists" Variable="NET_80102"/>
+        <util:DirectorySearch Id="DotNet80101" Path="[ProgramFiles64Folder]dotnet\sdk\8.0.101" Result="exists" Variable="NET_80101"/>
+        <util:DirectorySearch Id="DotNet80100" Path="[ProgramFiles64Folder]dotnet\sdk\8.0.100" Result="exists" Variable="NET_80100"/>
 
         <PackageGroup Id="DotNetSdk">
             <ExePackage Compressed="no"
-                        DetectCondition="DOTNET_SDK_INSTALLED"
+                        DetectCondition="NET_80201 OR NET_80200 OR NET_80102 OR NET_80101 OR NET_80100"
                         DownloadUrl="$(var.dotNetUrl)"
                         InstallCommand="/quiet /norestart"
                         PerMachine="yes"

--- a/scripts/WixBuildInstaller.cmd
+++ b/scripts/WixBuildInstaller.cmd
@@ -22,7 +22,7 @@ set TARGET_PLATFORM=x64
 set INSTALLER_FILE=Setup-%TARGET_PLATFORM%.exe
 set PACKAGE_URL=https://csspeechstorage.blob.core.windows.net/drop/private/ai/Azure.AI.CLI.%PACKAGE_VERSION%.nupkg
 
-REM Dependencies
+REM Dependencies (note: do NOT use redirecting URLs like aka.ms)
 set AZURE_CLI_VERSION=2.57.0
 set AZURE_CLI_INSTALLER=azure-cli-%AZURE_CLI_VERSION%-%TARGET_PLATFORM%.msi
 set AZURE_CLI_URL=https://azcliprod.blob.core.windows.net/msi/%AZURE_CLI_INSTALLER%
@@ -31,7 +31,8 @@ set DOTNET_INSTALLER=dotnet-sdk-%DOTNET_VERSION%-win-%TARGET_PLATFORM%.exe
 set DOTNET_URL=https://dotnetcli.azureedge.net/dotnet/Sdk/%DOTNET_VERSION%/%DOTNET_INSTALLER%
 set VCRT_VERSION=14.38.33135
 set VCRT_INSTALLER=VC_redist.%TARGET_PLATFORM%.exe
-set VCRT_URL=https://aka.ms/vs/17/release/%VCRT_VERSION%/%VCRT_INSTALLER%
+REM Below URL as redirected from https://aka.ms/vs/17/release/vc_redist.x64.exe while 14.38.33135 is the latest version.
+set VCRT_URL=https://download.visualstudio.microsoft.com/download/pr/c7707d68-d6ce-4479-973e-e2a3dc4341fe/1AD7988C17663CC742B01BEF1A6DF2ED1741173009579AD50A94434E54F56073/%VCRT_INSTALLER%
 
 REM Check for WiX toolset
 where candle.exe >nul 2>&1


### PR DESCRIPTION
Update checking of .NET SDK 8.x dependency to avoid downloading the latest release if there is at least some (older) 8.x version already installed, and change the VCRT download URL to direct (not aka.ms that may or may not work).