### PR TITLE
Studio view code snippet and learn docs

### DIFF
--- a/src/ai/.x/templates/openai-chat-js/Main.js
+++ b/src/ai/.x/templates/openai-chat-js/Main.js
@@ -1,21 +1,90 @@
-const { OpenAI } = require('openai');
+{{if {_IS_AUTHOR_COMMENT} }}
+ // Showcasing syntax differences for the same content:
+ //   The Learn docs use CommonJS module syntax, which includes `require` and `module.exports`
+ //     This is an older standard for working with modules in JavaScript and is widely supported, especially in Node.js.
+ //   The Studio "view code" uses ES6 module syntax, which includes `import` and `export`.
+ //     This is a newer standard for working with modules in JavaScript and is supported in modern browsers and Node.js versions
+{{endif}}
+{{if {_IS_STUDIO_VIEW_CODE_TEMPLATE}}}
+import { AzureOpenAI } from "openai";
+import { DefaultAzureCredential, getBearerTokenProvider } from "@azure/identity";
+{{else if {_IS_LEARN_DOC_TEMPLATE} || !{_IS_STUDIO_VIEW_CODE_TEMPLATE}}}
+const { OpenAI } = require("openai");
+{{endif}}
+{{if !{_IS_LEARN_DOC_TEMPLATE} || !{_IS_STUDIO_VIEW_CODE_TEMPLATE}}}
 const { {ClassName} } = require("./OpenAIChatCompletionsClass");
 const { readline } = require("./ReadLineWrapper");
+{{endif}}
 
-async function main() {
+{{if {_IS_LEARN_DOC_TEMPLATE}}}
+// Load the .env file if it exists
+const dotenv = require("dotenv");
+dotenv.config();
 
-  // What's the system prompt?
-  const AZURE_OPENAI_SYSTEM_PROMPT = process.env.AZURE_OPENAI_SYSTEM_PROMPT ?? "You are a helpful AI assistant.";
-
-  {{@include openai.js/create.openai.js}}
-
-  // Create the streaming chat completions helper
-  {{if contains(toupper("{OPENAI_CLOUD}"), "AZURE")}}
-  const chat = new {ClassName}(AZURE_OPENAI_CHAT_DEPLOYMENT, AZURE_OPENAI_SYSTEM_PROMPT, openai);
+  {{if {_IS_ENTRA_ID}}}
+  const scope = "https://cognitiveservices.azure.com/.default";
+  const azureADTokenProvider = getBearerTokenProvider(new DefaultAzureCredential(), scope);
   {{else}}
-  const chat = new {ClassName}(OPENAI_MODEL_NAME, AZURE_OPENAI_SYSTEM_PROMPT, openai);
+  // You will need to set these environment variables or edit the following values
+  const endpoint = process.env["AZURE_OPENAI_ENDPOINT"] || "<endpoint>";
+  const apiKey = process.env["AZURE_OPENAI_API_KEY"] || "<api key>";
   {{endif}}
-  
+  const apiVersion = "2024-05-01-preview";
+  const deployment = "gpt-4o"; //This must match your deployment name.
+  require("dotenv/config");
+{{endif}}
+
+{{if {_IS_STUDIO_VIEW_CODE_TEMPLATE}}}
+export async function main() {
+{{else}}
+async function main() {
+{{endif}}
+
+  {{if {_IS_LEARN_DOC_TEMPLATE}}}
+      const client = new AzureOpenAI({ endpoint, apiKey, apiVersion, deployment });
+      const result = await client.chat.completions.create({
+        messages: [
+        { role: "system", content: "You are a helpful assistant." },
+        { role: "user", content: "Does Azure OpenAI support customer managed keys?" },
+        { role: "assistant", content: "Yes, customer managed keys are supported by Azure OpenAI?" },
+        { role: "user", content: "Do other Azure AI services support this too?" },
+        ],
+        model: "",
+      });
+
+  {{else if {_IS_STUDIO_VIEW_CODE_TEMPLATE}}}
+      const scope = "https://cognitiveservices.azure.com/.default";
+      const azureADTokenProvider = getBearerTokenProvider(new DefaultAzureCredential(), scope);
+      const deployment = "gpt-35-turbo";
+      const apiVersion = "2024-04-01-preview";
+      const client = new AzureOpenAI({ azureADTokenProvider, deployment, apiVersion });
+      const result = await client.chat.completions.create({
+        messages:  [
+          { role: "system", content: "You are a helpful assistant. You will talk like a pirate." },
+          { role: "user", content: "Can you help me?" },
+        ],
+        model: '',
+      });
+
+  {{else}}
+    // What's the system prompt?
+    const AZURE_OPENAI_SYSTEM_PROMPT = process.env.AZURE_OPENAI_SYSTEM_PROMPT ?? "You are a helpful AI assistant.";
+
+    {{@include openai.js/create.openai.js}}
+    // Create the streaming chat completions helper
+    {{if contains(toupper("{OPENAI_CLOUD}"), "AZURE")}}
+    const chat = new {ClassName}(AZURE_OPENAI_CHAT_DEPLOYMENT, AZURE_OPENAI_SYSTEM_PROMPT, openai);
+    {{else}}
+    const chat = new {ClassName}(OPENAI_MODEL_NAME, AZURE_OPENAI_SYSTEM_PROMPT, openai);
+    {{endif}}
+  {{endif}}
+
+{{if {_IS_LEARN_DOC_TEMPLATE}} || {_IS_STUDIO_VIEW_CODE_TEMPLATE}}
+    for (const choice of result.choices) {
+      console.log(choice.message);
+    }
+  }
+{{else}}
   // Loop until the user types 'exit'
   while (true) {
 
@@ -31,10 +100,13 @@ async function main() {
   console.log('Bye!');
   process.exit();
 }
+{{endif}}
 
 main().catch((err) => {
   console.error("The sample encountered an error:", err);
   process.exit(1);
 });
 
+{{if !{_IS_STUDIO_VIEW_CODE_TEMPLATE}}}
 module.exports = { main };
+{{endif}}

--- a/src/ai/.x/templates/openai-chat-learndocs-js/_.json
+++ b/src/ai/.x/templates/openai-chat-learndocs-js/_.json
@@ -1,6 +1,6 @@
 {
-  "_LongName": "OpenAI Chat Completions",
-  "_ShortName": "openai-chat",
+  "_LongName": "OpenAI Chat Completions quickstart docs",
+  "_ShortName": "openai-chat-learndocs",
   "_Language": "JavaScript",
 
   "ClassName": "OpenAIChatCompletionsClass",
@@ -12,7 +12,5 @@
   "__process_env_or_import_meta_env": "process.env",
   "_IS_OPENAI_ASST_TEMPLATE": "false",
   "_IS_STUDIO_VIEW_CODE_TEMPLATE": "false",
-  "_IS_LEARN_DOC_TEMPLATE": "true",
-  "_IS_AUTHOR_COMMENT": "false",
-  "_IS_ENTRA_ID": "false"
+  "_IS_LEARN_DOC_TEMPLATE": "true"
 }

--- a/src/ai/.x/templates/openai-chat-learndocs-js/package.json
+++ b/src/ai/.x/templates/openai-chat-learndocs-js/package.json
@@ -1,0 +1,17 @@
+{
+    "name": "openai-chat",
+    "version": "1.0.0",
+    "description": "",
+    "main": "Main.js",
+    "scripts": {
+      "test": "echo \"Error: no test specified\" && exit 1",
+      "webpack": "webpack"
+    },
+    "author": "",
+    "license": "MIT",
+    "dependencies": {
+      "@azure/identity": "4.1.0",
+      "openai": "^4.31.0"
+    }
+  }
+  

--- a/src/ai/.x/templates/openai-chat-studio-viewcode-js/_.json
+++ b/src/ai/.x/templates/openai-chat-studio-viewcode-js/_.json
@@ -1,6 +1,6 @@
 {
-  "_LongName": "OpenAI Chat Completions",
-  "_ShortName": "openai-chat",
+  "_LongName": "OpenAI Chat Completions Studio view code",
+  "_ShortName": "openai-chat-studio-viewcode",
   "_Language": "JavaScript",
 
   "ClassName": "OpenAIChatCompletionsClass",
@@ -11,8 +11,6 @@
   "_IMPORT_EXPORT_USING_ES6": "false",
   "__process_env_or_import_meta_env": "process.env",
   "_IS_OPENAI_ASST_TEMPLATE": "false",
-  "_IS_STUDIO_VIEW_CODE_TEMPLATE": "false",
-  "_IS_LEARN_DOC_TEMPLATE": "true",
-  "_IS_AUTHOR_COMMENT": "false",
-  "_IS_ENTRA_ID": "false"
+  "_IS_STUDIO_VIEW_CODE_TEMPLATE": "true",
+  "_IS_LEARN_DOC_TEMPLATE": "false"
 }

--- a/src/ai/.x/templates/openai-chat-studio-viewcode-js/package.json
+++ b/src/ai/.x/templates/openai-chat-studio-viewcode-js/package.json
@@ -1,0 +1,17 @@
+{
+    "name": "openai-chat",
+    "version": "1.0.0",
+    "description": "",
+    "main": "Main.js",
+    "scripts": {
+      "test": "echo \"Error: no test specified\" && exit 1",
+      "webpack": "webpack"
+    },
+    "author": "",
+    "license": "MIT",
+    "dependencies": {
+      "@azure/identity": "4.1.0",
+      "openai": "^4.31.0"
+    }
+  }
+  


### PR DESCRIPTION
TODO:
- need to revisit template inheritance. Currently I've overwritten the `openai-chat` entry, but instead I need to have dirs for `learndocs` and `viewcode` (In any case, locally building the template is also now broken for me)

First attempt to create a template for chat completions in JS.

The aim is to merge the source materials from [this Learn docs page](https://learn.microsoft.com/en-us/azure/ai-services/openai/chatgpt-quickstart?tabs=command-line%2Cpython-new&pivots=programming-language-javascript#create-a-sample-application), the AI Studio Chat playground "view code" for JS, and the existing `ai cli` chat sample.

Of note, I've added two new _TEMPLATE var definitions and one new var `_IS_AUTHOR_COMMENT` for adding comments to template itself.

Once I have these being generated correctly, I'll add tests to validate. 
Then on to parameterizing and configuring source repos for embedding from this output.